### PR TITLE
Simplify posts creation

### DIFF
--- a/.github/workflows/quality-pipeline.yaml
+++ b/.github/workflows/quality-pipeline.yaml
@@ -1,0 +1,14 @@
+name: Quality pipeline
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  test-changes:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Generate the site
+      run: docker-compose up --abort-on-container-exit check

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-services: docker
-script: docker-compose up --build check
-notifications:
-  email:
-    on_success: never
-    on_failure: always

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,0 @@
-FROM jekyll/jekyll:3
-COPY Gemfile .
-RUN bundle install && rm Gemfile

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,15 @@
 source "https://rubygems.org"
 
-gem "json"
-gem "jekyll"
-gem "jekyll-sitemap"
-gem "jekyll-feed"
-gem "jekyll-paginate"
-gem "jekyll-gist"
+# If you want to use GitHub Pages, remove the "gem "jekyll"" above and
+# uncomment the line below. To upgrade, run `bundle update github-pages`.
+gem "github-pages", group: :jekyll_plugins
+
+# If you have any plugins, put them here!
+group :jekyll_plugins do
+  gem "json"
+  gem "jekyll"
+  gem "jekyll-sitemap"
+  gem "jekyll-feed"
+  gem "jekyll-paginate"
+  gem "jekyll-gist"
+end

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
-# A personal blog
+# The blog
+This repository holds static pages for <https://extsoft.pro>.
 
-[![Build Status](https://travis-ci.org/extsoft/extsoft.svg?branch=master)](https://travis-ci.org/extsoft/extsoft)
+![Quality pipeline](https://github.com/extsoft/extsoft/workflows/Quality%20pipeline/badge.svg)
 
 Made by [HPSTR Jekyll Theme](https://mmistakes.github.io/hpstr-jekyll-theme/theme-setup/)
 ([post templates](https://github.com/mmistakes/hpstr-jekyll-theme/tree/master/_posts))
 
-Run `docker-compose up --build preview` to have a local site's preview.
+Development notes
+- `docker-compose up preview` to have a local site's preview (<http://localhost>)
+- `docker-compose up --abort-on-container-exit check` to test a site generation

--- a/_config_dev.yml
+++ b/_config_dev.yml
@@ -1,0 +1,2 @@
+title: "Local site instance"
+url: ""

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -3,6 +3,7 @@
 <script src="{{ site.url }}/assets/js/scripts.min.js"></script>
 
 {% if site.google_analytics %}
+{% if jekyll.environment != 'localhost' %}
 <!-- Asynchronous Google Analytics snippet -->
 <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
@@ -14,6 +15,7 @@
   ga('require', 'linkid', 'linkid.js');
   ga('send', 'pageview');
 </script>
+{% endif %}
 {% endif %}
 
 {% if page.comments != false %}{% include disqus_comments.html %}{% endif %}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,21 @@
-version: '3'
+version: "3.7"
+
+x-default-settings: &default-settings
+    image: jekyll/jekyll:3
+    volumes:
+        - type: bind
+          source: ./
+          target: /code
+
 services:
     check:
-        image: extsoft/blog
-        build: .
-        command: "./preview.sh check"
-        volumes:
-            - .:/srv/jekyll
+        << : *default-settings
+        command: "sh -c 'cp -r /code/* . && jekyll clean && jekyll build --safe && jekyll doctor'"
     preview:
-        image: extsoft/blog
-        build: .
-        command: "./preview.sh preview"
+        << : *default-settings
+        command: "sh -c 'jekyll clean && jekyll serve --config _config.yml,_config_dev.yml --safe --watch --drafts'"
+        working_dir: /code
         ports:
-        - 4000:4000
-        volumes:
-        - .:/srv/jekyll
+            - 80:4000
+        environment:
+            - JEKYLL_ENV=localhost

--- a/preview.sh
+++ b/preview.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-set -e
-case $1 in
-    check)      jekyll clean && jekyll build && jekyll doctor ;;
-    preview)    jekyll serve --watch --drafts ;;
-    *)          echo "'check' or 'preview' is allowed"; exit -1 ;;
-esac
-


### PR DESCRIPTION
1. Use Jekyll environment as a key element of the condition to enable or
disable Google tracking. The `JEKYLL_ENV` will be set with a specific
value during a preview on the local environment.

2. Replace TravisCI with Github Actions.

3. Configure Jekyll build process similar to Github uses by enabling
`github-pages` gem (see Gemfile for details).

4. Simplify `docker-compose` configuration by using Jekyll Docker image
directly in compose configuration.